### PR TITLE
All support hearts will now toggle user support

### DIFF
--- a/src/visionlouisville/Gruntfile.js
+++ b/src/visionlouisville/Gruntfile.js
@@ -58,7 +58,8 @@ module.exports = function(grunt) {
           {
             dest: 'static/css/components.min.css',
             src: [
-              'static/components/normalize-css/normalize.css'
+              'static/components/normalize-css/normalize.css',
+              'static/components/normalize-css/hint.css'
             ]
           },
           {

--- a/src/visionlouisville/bower.json
+++ b/src/visionlouisville/bower.json
@@ -16,6 +16,7 @@
     "exif-js": "https://github.com/openplans/exif-js.git",
     "blueimp-load-image": "~1.9.1",
     "blueimp-canvas-to-blob": "~2.0.7",
-    "spin.js": "~1.3.0"
+    "spin.js": "~1.3.0",
+    "hint.css": "~1.3.0"
   }
 }

--- a/src/visionlouisville/jstemplates/item-tpl.html
+++ b/src/visionlouisville/jstemplates/item-tpl.html
@@ -21,19 +21,24 @@
         <em class="twitter-handle">@{{ author_details.username }}</em>
       </span>
 
-      <a href="#" class="support-link support{{#if_supported}} supported{{/if_supported}}"><img class="heart" src="/static/images/heart.png"> <span class="support-count total-support-count">{{ supporters.length }}</span></a>
+      <a href="#" class="support-link support{{#if_supported}} supported{{/if_supported}} hint--right"
+      {{^ if_authenticated}}data-hint="Sign in to support this {{app_config "vision"}}!"{{/if_authenticated}}>
 
-      {{^ if_authenticated}}
-      <div class="support-login-prompt is-hidden"><a href="{{ LOGIN_URL }}" class="btn btn-secondary btn-small">Sign in to support this idea! <img src="{{ STATIC_URL }}images/nav-twitter.png" class="icon-inline"></a></div>
-      {{/if_authenticated}}
+      <img class="heart" src="{{ STATIC_URL }}images/heart.png"> <span class="support-count total-support-count">{{ supporters.length }}</span></a>
 
     </header>
 
     <p class="vision-description">{{ formattext text }}</p>
 
     <footer class="vision-footer clearfix">
-      <a href="#" class="retweet-link{{#if_shared}} retweeted{{/if_shared}}"><span class="tweet-icon"><img class="tweet-icon-retweet" src="/static/images/retweet-icon.png"></span> Retweet</a>
-      <a href="#login-to-reply" class="reply-link show-reply"><span class="tweet-icon"><img class="tweet-icon-reply" src="/static/images/reply-icon.png"></span> Reply</a>
+      <a href="#" class="retweet-link{{#if_shared}} retweeted{{/if_shared}} hint--right"
+      {{^ if_authenticated}}data-hint="Sign in to retweet this {{app_config "vision"}}!"{{/if_authenticated}}>
+      <span class="tweet-icon"><img class="tweet-icon-retweet" src="/static/images/retweet-icon.png"></span> Retweet</a>
+
+      <a href="#login-to-reply" class="reply-link show-reply hint--right"
+      {{^ if_authenticated}}data-hint="Sign in to reply to this {{app_config "vision"}}!"{{/if_authenticated}}>
+
+      <span class="tweet-icon"><img class="tweet-icon-reply" src="/static/images/reply-icon.png"></span> Reply</a>
 
       {{# if category }}
       <!-- <a href="/{{visions_url_name}}/{{ category }}/list" class="category-link"><strong class="capitalize">{{ category }}</strong></a> -->
@@ -50,9 +55,6 @@
 
         <a href="#" class="btn btn-cancel cancel-retweet-action">Cancel</a> &nbsp;
         <a href="#" class="btn btn-primary confirm-retweet-action">Retweet</a>
-      </div>
-      {{^}}
-      <div class="retweet-login-prompt retweet-prompt-box is-hidden"><a href="{{ LOGIN_URL }}" class="btn btn-secondary btn-small">Sign in to share or reply to this vision! <img src="{{ STATIC_URL }}images/nav-twitter.png" class="icon-inline"></a></div>
       </div>
       {{/if_authenticated}}
     </footer>

--- a/src/visionlouisville/jstemplates/list-item-tpl.html
+++ b/src/visionlouisville/jstemplates/list-item-tpl.html
@@ -19,6 +19,9 @@
   <!-- <span class="vision-list-category-icon"><strong class="capitalize">{{ category }}</strong></span> -->
   {{/ if }}
 
-  <span class="support supported"><img class="heart heart-inline" src="/static/images/heart.png"> <span class="support-count total-support-count">{{ supporters.length }}</span></span>
+  <a href="#" class="support-link support{{#if_supported}} supported{{/if_supported}} hint--right"
+  {{^ if_authenticated}}data-hint="Sign in to support this {{app_config "vision"}}!"{{/if_authenticated}}>
+
+  <img class="heart heart-inline" src="/static/images/heart.png"> <span class="support-count total-support-count">{{ supporters.length }}</span></a>
 
 </article><!-- end .vision -->

--- a/src/visionlouisville/jstemplates/support-summary-tpl.html
+++ b/src/visionlouisville/jstemplates/support-summary-tpl.html
@@ -1,2 +1,4 @@
-<p class="support{{#if_supported}} supported{{/if_supported}}"><img class="heart heart-inline" src="/static/images/heart-beige.png"> <span class="support-count visionary-support-count">{{ supporters.length }}</span>
-  {{pluralize supporters.length 'Supporter' 'Supporters'}}</p>
+<a href="#" class="support-link support{{#if_supported}} supported{{/if_supported}} hint--right"
+{{^ if_authenticated}}data-hint="Sign in to support this {{app_config "vision"}}!"{{/if_authenticated}}>
+<img class="heart heart-inline" src="/static/images/heart-beige.png"> <span class="support-count visionary-support-count">{{ supporters.length }}</span>
+{{pluralize supporters.length 'Supporter' 'Supporters'}}</a>

--- a/src/visionlouisville/static/css/styles.css
+++ b/src/visionlouisville/static/css/styles.css
@@ -519,8 +519,8 @@ ul.user-menu:after {
   margin: 0;
   padding: 8px 10px;
 }
-.in-response-to a, 
-.in-response-to a:active, 
+.in-response-to a,
+.in-response-to a:active,
 .in-response-to a:visited {
   color: #7ec4d8;
   text-decoration: none;
@@ -715,6 +715,9 @@ a.support {
   padding: 15px 15px 15px 50px;
   box-shadow: 0 0 10px rgba(0,0,0,0.5);
   border-radius: 0 6px 6px 0;
+}
+.support-link {
+  text-decoration: none;
 }
 
 /* Vision Form */
@@ -940,7 +943,7 @@ h6.category-prompt {
   top: auto;
   right: auto;
   bottom: 0;
-  left: 0;  
+  left: 0;
   width: auto;
   height: auto;
   min-width: 100%;
@@ -970,8 +973,8 @@ h6.category-prompt {
           transition: opacity 1.2s;
 }
 .swiper-slide-visible .slide-header,
-.swiper-slide-visible .slide-image { 
-  opacity: 1; 
+.swiper-slide-visible .slide-image {
+  opacity: 1;
 }
 .slide-question {
   font-weight: 700;
@@ -979,7 +982,7 @@ h6.category-prompt {
   margin-bottom: 0.325em;
   text-shadow: 0 1px 0.25em rgba(0,0,0,0.75);
 }
-.slide-question a, 
+.slide-question a,
 .slide-question a:visited {
   color: #bff1ff;
   text-decoration: none;

--- a/src/visionlouisville/templates/visionlouisville/index.html
+++ b/src/visionlouisville/templates/visionlouisville/index.html
@@ -59,6 +59,7 @@
   {% if debug %}
   <link rel="stylesheet" href="{{ STATIC_URL }}components/normalize-css/normalize.css" type="text/css" media="screen, projection" />
   <link rel="stylesheet" href="{{ STATIC_URL }}components/swiper/dist/idangerous.swiper.css" type="text/css" media="screen, projection" />
+  <link rel="stylesheet" href="{{ STATIC_URL }}components/hint.css/hint.css" type="text/css" media="screen, projection" />
   <link rel="stylesheet" href="{{ STATIC_URL }}css/styles.css" type="text/css" media="screen, projection" />
 
   <script src="{{ STATIC_URL }}components/modernizr/modernizr.js"></script>


### PR DESCRIPTION
- Make a support mixin to share the handling across views
- Add hint.css and replace custom tooltips when an unauthenticated user tries to support, reply, or retweet a vision
- Update styles
- Add hint.css tooltips to the templates
