### PR TITLE
Restart listener on appconfig change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ script:
 
 notifications:
   email:
-    - dev@openplans.org
-    - mpoe@openplans.org
-  on_success: change
-  on_failure: always
+    recipients:
+      - dev@openplans.org
+      - mpoe@openplans.org
+    on_success: change
+    on_failure: always

--- a/src/hatch/migrations/0003_auto__add_field_appconfig_twitter_tracking_keywords__add_field_appconf.py
+++ b/src/hatch/migrations/0003_auto__add_field_appconfig_twitter_tracking_keywords__add_field_appconf.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'AppConfig.twitter_tracking_keywords'
+        db.add_column(u'hatch_appconfig', 'twitter_tracking_keywords',
+                      self.gf('django.db.models.fields.TextField')(default=''),
+                      keep_default=False)
+
+        # Adding field 'AppConfig.twitter_consumer_key'
+        db.add_column(u'hatch_appconfig', 'twitter_consumer_key',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=100),
+                      keep_default=False)
+
+        # Adding field 'AppConfig.twitter_consumer_secret'
+        db.add_column(u'hatch_appconfig', 'twitter_consumer_secret',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=100),
+                      keep_default=False)
+
+        # Adding field 'AppConfig.twitter_access_token'
+        db.add_column(u'hatch_appconfig', 'twitter_access_token',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=100),
+                      keep_default=False)
+
+        # Adding field 'AppConfig.twitter_access_token_secret'
+        db.add_column(u'hatch_appconfig', 'twitter_access_token_secret',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=100),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'AppConfig.twitter_tracking_keywords'
+        db.delete_column(u'hatch_appconfig', 'twitter_tracking_keywords')
+
+        # Deleting field 'AppConfig.twitter_consumer_key'
+        db.delete_column(u'hatch_appconfig', 'twitter_consumer_key')
+
+        # Deleting field 'AppConfig.twitter_consumer_secret'
+        db.delete_column(u'hatch_appconfig', 'twitter_consumer_secret')
+
+        # Deleting field 'AppConfig.twitter_access_token'
+        db.delete_column(u'hatch_appconfig', 'twitter_access_token')
+
+        # Deleting field 'AppConfig.twitter_access_token_secret'
+        db.delete_column(u'hatch_appconfig', 'twitter_access_token_secret')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'hatch.appconfig': {
+            'Meta': {'object_name': 'AppConfig'},
+            'allies_description': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True', 'blank': 'True'}),
+            'allies_label': ('django.db.models.fields.CharField', [], {'max_length': '250', 'null': 'True', 'blank': 'True'}),
+            'ally': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'ally_plural': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'share_title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'subtitle': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'twitter_access_token': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'twitter_access_token_secret': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'twitter_consumer_key': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'twitter_consumer_secret': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'twitter_handle': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'twitter_tracking_keywords': ('django.db.models.fields.TextField', [], {}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'vision': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'vision_plural': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'visionaries_description': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True', 'blank': 'True'}),
+            'visionaries_label': ('django.db.models.fields.CharField', [], {'max_length': '250', 'null': 'True', 'blank': 'True'}),
+            'visionary': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'visionary_plural': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'hatch.category': {
+            'Meta': {'object_name': 'Category'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'primary_key': 'True'}),
+            'prompt': ('django.db.models.fields.TextField', [], {}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'hatch.reply': {
+            'Meta': {'ordering': "('tweeted_at',)", 'object_name': 'Reply'},
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'replies'", 'to': u"orm['hatch.User']"}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'text': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'tweet': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'reply'", 'unique': 'True', 'to': u"orm['hatch.Tweet']"}),
+            'tweeted_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'vision': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'replies'", 'to': u"orm['hatch.Vision']"})
+        },
+        u'hatch.share': {
+            'Meta': {'object_name': 'Share'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'tweet': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'shares'", 'to': u"orm['hatch.Tweet']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'shares'", 'to': u"orm['hatch.User']"}),
+            'vision': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['hatch.Vision']"})
+        },
+        u'hatch.tweet': {
+            'Meta': {'object_name': 'Tweet'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'in_reply_to': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'tweet_replies'", 'null': 'True', 'to': u"orm['hatch.Tweet']"}),
+            'tweet_data': ('jsonfield.fields.JSONField', [], {'default': '{}', 'blank': 'True'}),
+            'tweet_id': ('django.db.models.fields.CharField', [], {'max_length': '64', 'primary_key': 'True'}),
+            'tweet_user_id': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'tweet_user_screen_name': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'hatch.user': {
+            'Meta': {'object_name': 'User'},
+            'checked_notifications_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'sm_not_found': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'}),
+            'visible_on_home': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        u'hatch.vision': {
+            'Meta': {'ordering': "('-tweeted_at',)", 'object_name': 'Vision'},
+            'app_tweet': ('django.db.models.fields.related.OneToOneField', [], {'blank': 'True', 'related_name': "'app_tweeted_vision'", 'unique': 'True', 'null': 'True', 'to': u"orm['hatch.Tweet']"}),
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'visions'", 'to': u"orm['hatch.User']"}),
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'visions'", 'null': 'True', 'to': u"orm['hatch.Category']"}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'featured': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'media_url': ('django.db.models.fields.URLField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
+            'sharers': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'sharers'", 'blank': 'True', 'through': u"orm['hatch.Share']", 'to': u"orm['hatch.User']"}),
+            'supporters': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'supported'", 'blank': 'True', 'to': u"orm['hatch.User']"}),
+            'text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'tweet': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'user_tweeted_vision'", 'unique': 'True', 'null': 'True', 'to': u"orm['hatch.Tweet']"}),
+            'tweeted_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['hatch']

--- a/src/hatch/migrations/0004_copy_existing_twitter_credentials.py
+++ b/src/hatch/migrations/0004_copy_existing_twitter_credentials.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        # Note: Don't use "from appname.models import ModelName". 
+        # Use orm.ModelName to refer to models in this application,
+        # and orm['appname.ModelName'] for models in other applications.
+
+        try:
+            from django.conf import settings
+
+            app_config = orm.AppConfig.objects.all()[0]
+            app_config.twitter_tracking_keywords = '\n'.join(settings.STREAMING_KEYWORDS)
+            app_config.twitter_handle = settings.TWITTER_USERNAME
+            app_config.twitter_consumer_key = settings.TWITTER_CONSUMER_KEY
+            app_config.twitter_consumer_secret = settings.TWITTER_CONSUMER_SECRET
+            app_config.twitter_access_token = settings.TWITTER_ACCESS_TOKEN
+            app_config.twitter_access_token_secret = settings.TWITTER_ACCESS_SECRET
+
+            app_config.save()
+        except:
+            return
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'hatch.appconfig': {
+            'Meta': {'object_name': 'AppConfig'},
+            'allies_description': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True', 'blank': 'True'}),
+            'allies_label': ('django.db.models.fields.CharField', [], {'max_length': '250', 'null': 'True', 'blank': 'True'}),
+            'ally': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'ally_plural': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'share_title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'subtitle': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'twitter_access_token': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'twitter_access_token_secret': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'twitter_consumer_key': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'twitter_consumer_secret': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'twitter_handle': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'twitter_tracking_keywords': ('django.db.models.fields.TextField', [], {}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'vision': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'vision_plural': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'visionaries_description': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True', 'blank': 'True'}),
+            'visionaries_label': ('django.db.models.fields.CharField', [], {'max_length': '250', 'null': 'True', 'blank': 'True'}),
+            'visionary': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'visionary_plural': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'hatch.category': {
+            'Meta': {'object_name': 'Category'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'primary_key': 'True'}),
+            'prompt': ('django.db.models.fields.TextField', [], {}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'hatch.reply': {
+            'Meta': {'ordering': "('tweeted_at',)", 'object_name': 'Reply'},
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'replies'", 'to': u"orm['hatch.User']"}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'text': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'tweet': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'reply'", 'unique': 'True', 'to': u"orm['hatch.Tweet']"}),
+            'tweeted_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'vision': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'replies'", 'to': u"orm['hatch.Vision']"})
+        },
+        u'hatch.share': {
+            'Meta': {'object_name': 'Share'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'tweet': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'shares'", 'to': u"orm['hatch.Tweet']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'shares'", 'to': u"orm['hatch.User']"}),
+            'vision': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['hatch.Vision']"})
+        },
+        u'hatch.tweet': {
+            'Meta': {'object_name': 'Tweet'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'in_reply_to': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'tweet_replies'", 'null': 'True', 'to': u"orm['hatch.Tweet']"}),
+            'tweet_data': ('jsonfield.fields.JSONField', [], {'default': '{}', 'blank': 'True'}),
+            'tweet_id': ('django.db.models.fields.CharField', [], {'max_length': '64', 'primary_key': 'True'}),
+            'tweet_user_id': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'tweet_user_screen_name': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'hatch.user': {
+            'Meta': {'object_name': 'User'},
+            'checked_notifications_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'sm_not_found': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'}),
+            'visible_on_home': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        u'hatch.vision': {
+            'Meta': {'ordering': "('-tweeted_at',)", 'object_name': 'Vision'},
+            'app_tweet': ('django.db.models.fields.related.OneToOneField', [], {'blank': 'True', 'related_name': "'app_tweeted_vision'", 'unique': 'True', 'null': 'True', 'to': u"orm['hatch.Tweet']"}),
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'visions'", 'to': u"orm['hatch.User']"}),
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'visions'", 'null': 'True', 'to': u"orm['hatch.Category']"}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'featured': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'media_url': ('django.db.models.fields.URLField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
+            'sharers': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'sharers'", 'blank': 'True', 'through': u"orm['hatch.Share']", 'to': u"orm['hatch.User']"}),
+            'supporters': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'supported'", 'blank': 'True', 'to': u"orm['hatch.User']"}),
+            'text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'tweet': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'user_tweeted_vision'", 'unique': 'True', 'null': 'True', 'to': u"orm['hatch.Tweet']"}),
+            'tweeted_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['hatch']
+    symmetrical = True

--- a/src/hatch/services.py
+++ b/src/hatch/services.py
@@ -1,9 +1,9 @@
-from django.conf import settings
 from django.core import cache as django_cache
 from twitter import Twitter, OAuth, TwitterHTTPError
 from twitter.stream import TwitterStream
 from urlparse import parse_qs
 import re
+from .models import AppConfig
 from .cache import cache_buffer as cache
 from .utils import chunk
 
@@ -264,11 +264,12 @@ class TwitterService (object):
                      'provider') % social_auth.provider
                 )
 
+            app_config = AppConfig.get()
             oauth_args = (
                 access_token['oauth_token'][0],
                 access_token['oauth_token_secret'][0],
-                settings.TWITTER_CONSUMER_KEY,
-                settings.TWITTER_CONSUMER_SECRET
+                app_config.twitter_consumer_key,
+                app_config.twitter_consumer_secret,
             )
             # Cache for just long enough to complete the current batch of
             # lookups without having to hit the DB again.
@@ -281,11 +282,12 @@ class TwitterService (object):
     # against Twitter on behalf of the app
     # ==================================================================
     def get_app_oauth(self):
+        app_config = AppConfig.get()
         return OAuth(
-            settings.TWITTER_ACCESS_TOKEN,
-            settings.TWITTER_ACCESS_SECRET,
-            settings.TWITTER_CONSUMER_KEY,
-            settings.TWITTER_CONSUMER_SECRET,
+            app_config.twitter_access_token,
+            app_config.twitter_access_token_secret,
+            app_config.twitter_consumer_key,
+            app_config.twitter_consumer_secret,
         )
 
     def get_api(self, on_behalf_of=None):

--- a/src/hatch/settings.py
+++ b/src/hatch/settings.py
@@ -26,6 +26,9 @@ DATABASES = {
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = []
 
+APP_CONFIG_CACHE_KEY = 'app_config'
+APP_CONFIG_INDEX = 0
+
 ###############################################################################
 #
 # Time Zones

--- a/src/hatch/tasks.py
+++ b/src/hatch/tasks.py
@@ -6,7 +6,8 @@ from django.db.models import Max
 from django.db.transaction import commit_on_success
 from celery import task
 from time import sleep
-from .models import User, Tweet
+from .cache import cache_buffer
+from .models import User, Tweet, AppConfig
 from .utils import chunk
 from .services import default_twitter_service as twitter_service
 
@@ -39,7 +40,9 @@ def listen_for_tweets():
 
     log.info('\n*** Listening for tweets...\n')
 
-    streaming_keywords = settings.STREAMING_KEYWORDS
+    app_config = AppConfig.get(cache=cache)
+    streaming_keywords = app_config.twitter_tracking_keywords.split('\n')
+    streaming_keywords = map(lambda keyword: keyword.strip(), streaming_keywords)
 
     def contains_keywords(text):
         """


### PR DESCRIPTION
Allow an admin to set up Twitter credentials and keywords from the admin. The listener restarts automatically afterwards.
